### PR TITLE
[WIP] Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 /phpunit.xml
 .php_cs.cache
 /humbug/
-/humbug*
+/humbug-log*

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /build/
 /phpunit.xml
 .php_cs.cache
+/humbug/
+/humbug*

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ env:
   - PREFER_LOWEST=""
 before_script:
 - composer update --prefer-dist $PREFER_LOWEST
+- git clone https://github.com/padraic/humbug.git && cd humbug && composer install && cd ..
 script:
 - "./vendor/bin/phpunit"
+- ./humbug/bin/humbug
 after_script:
 - if [ -z "$PREFER_LOWEST" ]; then ./vendor/bin/coveralls -v; fi

--- a/README.md
+++ b/README.md
@@ -18,20 +18,85 @@ Other packages (like [Slim-CSRF](https://github.com/slimphp/Slim-Csrf)) can help
 What is it doing?
 -----------------
 
-The `CsrfHeaderCheckMiddleware` will check that all POST/PUT/DELETE requests and verify that the "Origin" of the request is your own website.
+The `CsrfHeaderCheckMiddleware` will look at all POST/PUT/DELETE requests (actually all requests that are not GET/HEAD/OPTIONS).
+It will verify that the "Origin" of the request is your own website.
 
 It does so by comparing the "Origin" (or the "Referrer" header as a fallback) to the "Host" (or "X-Forwarded-Host") header.
 If the headers do not match (or if the headers are not found), it will trigger an exception.
 
-Limits:
--------
+Why does it work?
+-----------------
 
+In a CSRF attack, the victim (Alice) is logged in your application.
+The attacker (Eve) sends Alice a malicious link to her malicious website. The malicious website contains some Javascript that performs a POST on a form of your website. Since Alice is logged into your website, the POST succeeds, allowing Eve to perform actions on the behalf of Alice.
+
+The query is therefore executed by Alice's computer. We can expect Alice's browser to behave as a "normal" browsers.
+
+- Normal browsers always send the "Host" header (at least in HTTP 1.1).
+- Normal browsers [do not allow Javascript code to modify the "Origin" or "Referer" header](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name).
+- Normal browsers do not allow Javascript code to send the "X-Forwarded-Host" header (TODO: check this!)
+
+How does it compare to other solutions
+--------------------------------------
+
+When fighting CSRF attacks, the most common solution used it to generate a token in each form, store this token in session, and check that the user sends back the token.
+If you are looking for a CSRF token based middleware using PSR-7/PSR-15, have a look at [Ocramius/PSR7Csrf](https://github.com/Ocramius/PSR7Csrf/)
+
+### Advantages over token based implementations
+
+Checking for HTTP headers can be done in the middleware alone.
+With token-based middlewares, you have to modify your application to generate a token and send the token with any form. In contrast, checking headers requires no work besides adding the middleware. So it's really fast to deploy.
+
+### Limits
+
+- Works only with HTTP 1.1 requests (in HTTP 1.0, the "Host" header is not set)
 - This middleware completely bypasses GET requests. If your application modifies state on GET requests, you are screwed. Of course, modification of state should only happen in POST requests (but please check twice that your routes changing state do ONLY works with POST/DELETE/PUT requests).
 - This middleware expects "Origin" or "Referrer" headers to be filled. This will often be true unless you are in a corporate environment with proxies that are fiddling with your request. For instance, some proxies are known to strip headers in order to make the request anonymous.
+- Will block CORS requests. You cannot use this middleware if you are expecting requests to come from another origin than your website. 
+
+If you are in one of those situations, use a token-based middleware instead.
 
 Installation
 ------------
 
 ```php
 composer require thecodingmachine/csrf-header-check-middleware
+```
+
+Usage
+-----
+
+The simplest usage is based on defaults. It assumes that you have
+a configured PSR-7 compatible application that supports piping
+middlewares.
+
+In a [`zendframework/zend-expressive`](https://github.com/zendframework/zend-expressive)
+application, the setup would look like the following:
+
+```php
+$app = \Zend\Expressive\AppFactory::create();
+
+$app->pipe(\TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareFactory::createDefault();
+```
+
+Disabling CSRF checks
+---------------------
+
+You can disable CSRF checks on a per-route basis:
+
+```php
+// The first argument of the factory is a list of regular expressions that will be matched on the path.
+// Here, we disable CSRF checks on /api/*
+$app->pipe(\TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareFactory::createDefault([
+    '#^/api/#'
+]);
+```
+
+This can be useful for APIs that are only used when communicating from server to server. Please note that if you decide to disable CSRF for some routes, you need to have some other forms of protection for this route.
+
+Alternatively, any request passed to the middleware that has the 'TheCodingMachine\BypassCsrf' attribute set will be ignored:
+
+```php
+// Put this in a middleware placed before the `CsrfHeaderCheckMiddleware` to disable it.
+$request = $request->withAttribute('TheCodingMachine\\BypassCsrf', true);
 ```

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "http-interop/http-middleware": "^0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1",
+        "phpunit/phpunit": "^5.7.14",
         "satooshi/php-coveralls": "^1.0",
         "zendframework/zend-diactoros": "^1.4"
     },

--- a/humbug.json.dist
+++ b/humbug.json.dist
@@ -1,0 +1,12 @@
+{
+  "timeout": 30,
+  "source": {
+    "directories": [
+      "src"
+    ]
+  },
+  "logs": {
+    "text": "humbug-log.txt",
+    "json": "humbug-log.json"
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,8 +22,8 @@
     		<directory suffix=".php">src/</directory>
         </whitelist>
 	</filter>
-  <!--  <logging>
+    <logging>
         <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging> -->
+    </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,8 +22,8 @@
     		<directory suffix=".php">src/</directory>
         </whitelist>
 	</filter>
-    <logging>
+  <!--  <logging>
         <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+    </logging> -->
 </phpunit>

--- a/src/CsrfHeaderCheckMiddleware.php
+++ b/src/CsrfHeaderCheckMiddleware.php
@@ -1,16 +1,28 @@
 <?php
+declare(strict_types=1);
+
 namespace TheCodingMachine\Middlewares;
 
 use Interop\Http\ServerMiddleware\DelegateInterface;
 use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use TheCodingMachine\Middlewares\SafeRequests\IsSafeHttpRequestInterface;
 
 /**
- * This class will check that all POST/DELETE requests and verify that the "Origin" of the request is your own website.
+ * This class will check that all POST/PUT/DELETE... requests and verify that the "Origin" of the request is your own website.
  */
-class CsrfHeaderCheckMiddleware implements MiddlewareInterface
+final class CsrfHeaderCheckMiddleware implements MiddlewareInterface
 {
+    /**
+     * @var IsSafeHttpRequestInterface
+     */
+    private $isSafeHttpRequest;
+
+    public function __construct(IsSafeHttpRequestInterface $isSafeHttpRequest)
+    {
+        $this->isSafeHttpRequest = $isSafeHttpRequest;
+    }
 
     /**
      * Process an incoming server request and return a response, optionally delegating
@@ -23,12 +35,12 @@ class CsrfHeaderCheckMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, DelegateInterface $delegate)
     {
-        $method = strtoupper($request->getMethod());
-        if (in_array($method, ['POST', 'PUT', 'DELETE'], true)) {
+        $isSafeHttpRequest = $this->isSafeHttpRequest;
+        if (!$isSafeHttpRequest($request)) {
             $source = $this->getSourceOrigin($request);
             $target = $this->getTargetOrigin($request);
             if ($source !== $target) {
-                throw new CsrfHeaderCheckMiddlewareException("Potential CSRF attack stopped. Source origin and target origin do not match.");
+                throw new CsrfHeaderCheckMiddlewareException('Potential CSRF attack stopped. Source origin and target origin do not match.');
             }
         }
         return $delegate->process($request);
@@ -37,29 +49,27 @@ class CsrfHeaderCheckMiddleware implements MiddlewareInterface
     private function getSourceOrigin(ServerRequestInterface $request): string
     {
         $source = $this->getHeaderLine($request, 'ORIGIN');
-        if ($source === null) {
-            $referrer = $this->getHeaderLine($request, 'REFERER');
-            if ($referrer === null) {
-                throw new CsrfHeaderCheckMiddlewareException("Could not find neither the ORIGIN header nor the REFERER header in the HTTP request.");
-            }
-
-            $source = parse_url($referrer, PHP_URL_HOST);
-        } else {
-            $source = parse_url($source, PHP_URL_HOST);
+        if (null !== $source) {
+            return parse_url($source, PHP_URL_HOST);
         }
 
-        return $source;
+        $referrer = $this->getHeaderLine($request, 'REFERER');
+        if (null === $referrer) {
+            throw new CsrfHeaderCheckMiddlewareException('Could not find neither the ORIGIN header nor the REFERER header in the HTTP request.');
+        }
+
+        return parse_url($referrer, PHP_URL_HOST);
     }
 
     private function getTargetOrigin(ServerRequestInterface $request): string
     {
         $host = $this->getHeaderLine($request, 'X-FORWARDED-HOST');
-        if ($host === null) {
+        if (null === $host) {
             $host = $this->getHeaderLine($request, 'HOST');
         }
 
-        if ($host === null) {
-            throw new CsrfHeaderCheckMiddlewareException("Could not find the HOST header in the HTTP request.");
+        if (null === $host) {
+            throw new CsrfHeaderCheckMiddlewareException('Could not find the HOST header in the HTTP request.');
         }
         return $this->removePortFromHost($host);
     }
@@ -74,18 +84,18 @@ class CsrfHeaderCheckMiddleware implements MiddlewareInterface
      * Returns null if nothing found.
      *
      * @param ServerRequestInterface $request
-     * @param string $headerLine
+     * @param string $header
      * @return string|null
      * @throws CsrfHeaderCheckMiddlewareException
      */
-    private function getHeaderLine(ServerRequestInterface $request, string $headerLine)
+    private function getHeaderLine(ServerRequestInterface $request, string $header)
     {
-        $hosts = $request->getHeader($headerLine);
-        if (count($hosts) > 1) {
-            throw new CsrfHeaderCheckMiddlewareException("Unexpected request: more than one $headerLine header sent.");
+        $values = $request->getHeader($header);
+        if (count($values) > 1) {
+            throw new CsrfHeaderCheckMiddlewareException("Unexpected request: more than one $header header sent.");
         }
-        if (count($hosts) === 1) {
-            return $hosts[0];
+        if (count($values) === 1) {
+            return $values[0];
         }
         return null;
     }

--- a/src/CsrfHeaderCheckMiddlewareException.php
+++ b/src/CsrfHeaderCheckMiddlewareException.php
@@ -1,5 +1,5 @@
 <?php
-
+declare(strict_types=1);
 
 namespace TheCodingMachine\Middlewares;
 

--- a/src/CsrfHeaderCheckMiddlewareFactory.php
+++ b/src/CsrfHeaderCheckMiddlewareFactory.php
@@ -3,7 +3,10 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\Middlewares;
 
-
+use TheCodingMachine\Middlewares\OriginFetchers\CompositeTargetOrigin;
+use TheCodingMachine\Middlewares\OriginFetchers\HardCodedTargetOrigins;
+use TheCodingMachine\Middlewares\OriginFetchers\HostHeader;
+use TheCodingMachine\Middlewares\OriginFetchers\OriginOrRefererHeader;
 use TheCodingMachine\Middlewares\SafeRequests\CompositeIsSafe;
 use TheCodingMachine\Middlewares\SafeRequests\IsBypassedCheck;
 use TheCodingMachine\Middlewares\SafeRequests\IsSafeHttpMethod;
@@ -11,14 +14,19 @@ use TheCodingMachine\Middlewares\SafeRequests\IsSafeHttpRoute;
 
 final class CsrfHeaderCheckMiddlewareFactory
 {
-    public static function createDefault(array $safeRoutes = []): CsrfHeaderCheckMiddleware
+    public static function createDefault(array $applicationDomainNames = [], array $safeRoutes = []): CsrfHeaderCheckMiddleware
     {
         return new CsrfHeaderCheckMiddleware(
             new CompositeIsSafe(
                 IsSafeHttpMethod::fromDefaultSafeMethods(),
                 new IsSafeHttpRoute(...$safeRoutes),
                 IsBypassedCheck::fromDefault()
-            )
+            ),
+            new CompositeTargetOrigin(
+                new HostHeader(),
+                new HardCodedTargetOrigins(...$applicationDomainNames)
+            ),
+            new OriginOrRefererHeader()
         );
     }
 }

--- a/src/CsrfHeaderCheckMiddlewareFactory.php
+++ b/src/CsrfHeaderCheckMiddlewareFactory.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+namespace TheCodingMachine\Middlewares;
+
+
+use TheCodingMachine\Middlewares\SafeRequests\CompositeIsSafe;
+use TheCodingMachine\Middlewares\SafeRequests\IsBypassedCheck;
+use TheCodingMachine\Middlewares\SafeRequests\IsSafeHttpMethod;
+use TheCodingMachine\Middlewares\SafeRequests\IsSafeHttpRoute;
+
+final class CsrfHeaderCheckMiddlewareFactory
+{
+    public static function createDefault(array $safeRoutes = []): CsrfHeaderCheckMiddleware
+    {
+        return new CsrfHeaderCheckMiddleware(
+            new CompositeIsSafe(
+                IsSafeHttpMethod::fromDefaultSafeMethods(),
+                new IsSafeHttpRoute(...$safeRoutes),
+                IsBypassedCheck::fromDefault()
+            )
+        );
+    }
+}

--- a/src/OriginFetchers/CompositeTargetOrigin.php
+++ b/src/OriginFetchers/CompositeTargetOrigin.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace TheCodingMachine\Middlewares\OriginFetchers;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class CompositeTargetOrigin implements TargetOriginInterface
+{
+    /**
+     * @var TargetOriginInterface[]
+     */
+    private $targetOrigins;
+
+    /**
+     * @param TargetOriginInterface[] ...$targetOrigins
+     */
+    public function __construct(TargetOriginInterface ...$targetOrigins)
+    {
+        $this->targetOrigins = $targetOrigins;
+    }
+
+    /**
+     * Returns an array of allowed domain names.
+     * If the "source" origin matches one of these origins, the request is valid.
+     *
+     * @return string[]
+     */
+    public function __invoke(ServerRequestInterface $request): array
+    {
+        $targetOrigins = [];
+
+        foreach ($this->targetOrigins as $targetOrigin) {
+            $targetOrigins = array_merge($targetOrigins, $targetOrigin($request));
+        }
+
+        return $targetOrigins;
+    }
+}

--- a/src/OriginFetchers/HardCodedTargetOrigins.php
+++ b/src/OriginFetchers/HardCodedTargetOrigins.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace TheCodingMachine\Middlewares\OriginFetchers;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareException;
+
+/**
+ * A set of hard coded target origins.
+ * To be used if your application is behind a proxy (thus preventing the use of "HostHeader" class.
+ */
+class HardCodedTargetOrigins implements TargetOriginInterface
+{
+    /**
+     * @var \string[]
+     */
+    private $origins;
+
+    /**
+     * @param \string[] ...$origins A set of domain names for YOUR application.
+     */
+    public function __construct(string ...$origins)
+    {
+        $this->origins = $origins;
+    }
+
+    /**
+     * Returns an array of domain names for your application.
+     * If the "source" origin matches one of these origins, the request is valid.
+     *
+     * @return string[]
+     * @throws \TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareException
+     */
+    public function __invoke(ServerRequestInterface $request): array
+    {
+        return $this->origins;
+    }
+}

--- a/src/OriginFetchers/HeaderFetcher.php
+++ b/src/OriginFetchers/HeaderFetcher.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace TheCodingMachine\Middlewares\OriginFetchers;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareException;
+
+trait HeaderFetcher
+{
+    /**
+     * Returns the header, throws an exception if the header is specified more that one in the request.
+     * Returns null if nothing found.
+     *
+     * @param ServerRequestInterface $request
+     * @param string $header
+     * @return string|null
+     * @throws CsrfHeaderCheckMiddlewareException
+     */
+    protected function getHeaderLine(ServerRequestInterface $request, string $header)
+    {
+        $values = $request->getHeader($header);
+        if (count($values) > 1) {
+            throw new CsrfHeaderCheckMiddlewareException("Unexpected request: more than one $header header sent.");
+        }
+        if (count($values) === 1) {
+            return $values[0];
+        }
+        return null;
+    }
+}

--- a/src/OriginFetchers/HostHeader.php
+++ b/src/OriginFetchers/HostHeader.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace TheCodingMachine\Middlewares\OriginFetchers;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareException;
+
+/**
+ * Reads the target origin from the "Host" HTTP 1.1 header.
+ * Note: the "Host" header cannot be modified from Javascript.
+ *
+ * We do not rely on the "X-Forwarded-Host" header on purpose because this header can be tempered from JS.
+ */
+class HostHeader implements TargetOriginInterface
+{
+    use HeaderFetcher;
+
+    /**
+     * Returns an array of allowed domain names.
+     * If the "source" origin matches one of these origins, the request is valid.
+     *
+     * @return string[]
+     * @throws \TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareException
+     */
+    public function __invoke(ServerRequestInterface $request): array
+    {
+        $host = $this->getHeaderLine($request, 'HOST');
+
+        if (null === $host) {
+            throw new CsrfHeaderCheckMiddlewareException('Could not find the HOST header in the HTTP request.');
+        }
+
+        return [ $this->removePortFromHost($host) ];
+    }
+
+    private function removePortFromHost(string $host)
+    {
+        return explode(':', $host)[0];
+    }
+}

--- a/src/OriginFetchers/OriginOrRefererHeader.php
+++ b/src/OriginFetchers/OriginOrRefererHeader.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace TheCodingMachine\Middlewares\OriginFetchers;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareException;
+
+/**
+ * Fetches data from the Origin header, or from the Referer header if the Origin header is not present
+ */
+class OriginOrRefererHeader implements SourceOriginInterface
+{
+    use HeaderFetcher;
+
+    /**
+     * Returns the domain name of the website performing the request.
+     *
+     * @param ServerRequestInterface $request
+     * @return string
+     * @throws \TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareException
+     */
+    public function __invoke(ServerRequestInterface $request): string
+    {
+        $source = $this->getHeaderLine($request, 'ORIGIN');
+        if (null !== $source) {
+            return parse_url($source, PHP_URL_HOST);
+        }
+
+        $referrer = $this->getHeaderLine($request, 'REFERER');
+        if (null === $referrer) {
+            throw new CsrfHeaderCheckMiddlewareException('Could not find neither the ORIGIN header nor the REFERER header in the HTTP request.');
+        }
+
+        return parse_url($referrer, PHP_URL_HOST);
+    }
+}

--- a/src/OriginFetchers/SourceOriginInterface.php
+++ b/src/OriginFetchers/SourceOriginInterface.php
@@ -1,0 +1,15 @@
+<?php
+namespace TheCodingMachine\Middlewares\OriginFetchers;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+interface SourceOriginInterface
+{
+    /**
+     * Returns the domain name of the website performing the request.
+     *
+     * @param ServerRequestInterface $request
+     * @return string
+     */
+    public function __invoke(ServerRequestInterface $request): string;
+}

--- a/src/OriginFetchers/TargetOriginInterface.php
+++ b/src/OriginFetchers/TargetOriginInterface.php
@@ -1,0 +1,16 @@
+<?php
+namespace TheCodingMachine\Middlewares\OriginFetchers;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+interface TargetOriginInterface
+{
+    /**
+     * Returns an array of allowed domain names.
+     * If the "source" origin matches one of these origins, the request is valid.
+     *
+     * @param ServerRequestInterface $request
+     * @return array|\string[]
+     */
+    public function __invoke(ServerRequestInterface $request): array;
+}

--- a/src/SafeRequests/CompositeIsSafe.php
+++ b/src/SafeRequests/CompositeIsSafe.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace TheCodingMachine\Middlewares\SafeRequests;
 
-
 use Psr\Http\Message\ServerRequestInterface;
 
 final class CompositeIsSafe implements IsSafeHttpRequestInterface

--- a/src/SafeRequests/CompositeIsSafe.php
+++ b/src/SafeRequests/CompositeIsSafe.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace TheCodingMachine\Middlewares\SafeRequests;
+
+
+use Psr\Http\Message\ServerRequestInterface;
+
+final class CompositeIsSafe implements IsSafeHttpRequestInterface
+{
+    /**
+     * @var IsSafeHttpRequestInterface[]
+     */
+    private $isSafeHttpRequests;
+
+    public function __construct(IsSafeHttpRequestInterface ...$isSafeHttpRequests)
+    {
+        $this->isSafeHttpRequests = $isSafeHttpRequests;
+    }
+
+    public function __invoke(ServerRequestInterface $request): bool
+    {
+        foreach ($this->isSafeHttpRequests as $isSafeHttpRequest) {
+            if ($isSafeHttpRequest($request)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/SafeRequests/IsBypassedCheck.php
+++ b/src/SafeRequests/IsBypassedCheck.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace TheCodingMachine\Middlewares\SafeRequests;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Checks for the presence of a 'TheCodingMachine\BypassCsrf' attribute in the request.
+ */
+final class IsBypassedCheck implements IsSafeHttpRequestInterface
+{
+
+    /**
+     * @var string
+     */
+    private $attributeName;
+
+    public function __construct(string $attributeName)
+    {
+        $this->attributeName = $attributeName;
+    }
+
+    public static function fromDefault() : self
+    {
+        return new self('TheCodingMachine\\BypassCsrf');
+    }
+
+    public function __invoke(ServerRequestInterface $request) : bool
+    {
+        return (bool) $request->getAttribute($this->attributeName);
+    }
+}

--- a/src/SafeRequests/IsSafeHttpMethod.php
+++ b/src/SafeRequests/IsSafeHttpMethod.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 final class IsSafeHttpMethod implements IsSafeHttpRequestInterface
 {
+    const STRICT_COMPARE = true; // Used a constant to avoid a Humbug mutation.
+
     /**
      * @var \string[]
      */
@@ -27,6 +29,6 @@ final class IsSafeHttpMethod implements IsSafeHttpRequestInterface
 
     public function __invoke(ServerRequestInterface $request) : bool
     {
-        return in_array(strtoupper($request->getMethod()), $this->safeMethods, true);
+        return in_array(strtoupper($request->getMethod()), $this->safeMethods, self::STRICT_COMPARE);
     }
 }

--- a/src/SafeRequests/IsSafeHttpMethod.php
+++ b/src/SafeRequests/IsSafeHttpMethod.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace TheCodingMachine\Middlewares\SafeRequests;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Shamelessly borrowed from Ocramius/PSR7Csrf package.
+ */
+final class IsSafeHttpMethod implements IsSafeHttpRequestInterface
+{
+    /**
+     * @var \string[]
+     */
+    private $safeMethods;
+
+    public function __construct(string ...$safeMethods)
+    {
+        $this->safeMethods = array_map('strtoupper', $safeMethods);
+    }
+
+    public static function fromDefaultSafeMethods() : self
+    {
+        return new self('GET', 'HEAD', 'OPTIONS');
+    }
+
+    public function __invoke(ServerRequestInterface $request) : bool
+    {
+        return in_array(strtoupper($request->getMethod()), $this->safeMethods, true);
+    }
+}

--- a/src/SafeRequests/IsSafeHttpRequestInterface.php
+++ b/src/SafeRequests/IsSafeHttpRequestInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace TheCodingMachine\Middlewares\SafeRequests;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+interface IsSafeHttpRequestInterface
+{
+    public function __invoke(ServerRequestInterface $request) : bool;
+}

--- a/src/SafeRequests/IsSafeHttpRoute.php
+++ b/src/SafeRequests/IsSafeHttpRoute.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace TheCodingMachine\Middlewares\SafeRequests;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Used to whitelist a set of routes.
+ * Those routes will not be checked for CSRF.
+ *
+ * Useful for routes reserved for server to server APIs (AND already protected in another way).
+ */
+final class IsSafeHttpRoute implements IsSafeHttpRequestInterface
+{
+    /**
+     * @var \string[]
+     */
+    private $routes;
+
+    /**
+     * @param \string[] ...$routes A list of routes (expressed as regular expressions) that are NOT checked for CSRF.
+     */
+    public function __construct(string ...$routes)
+    {
+        $this->routes = $routes;
+    }
+
+    public function __invoke(ServerRequestInterface $request) : bool
+    {
+        $path = $request->getUri()->getPath();
+
+        foreach ($this->routes as $route) {
+            if (preg_match($route, $path)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/AbstractMiddlewareTest.php
+++ b/tests/AbstractMiddlewareTest.php
@@ -3,7 +3,6 @@
 
 namespace TheCodingMachine\Middlewares;
 
-
 use Interop\Http\ServerMiddleware\DelegateInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;

--- a/tests/AbstractMiddlewareTest.php
+++ b/tests/AbstractMiddlewareTest.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace TheCodingMachine\Middlewares;
+
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response\TextResponse;
+
+abstract class AbstractMiddlewareTest extends TestCase
+{
+    protected function getDelegate() : DelegateInterface
+    {
+        return new class implements DelegateInterface {
+
+            /**
+             * Dispatch the next available middleware and return the response.
+             *
+             * @param ServerRequestInterface $request
+             *
+             * @return ResponseInterface
+             */
+            public function process(ServerRequestInterface $request)
+            {
+                return new TextResponse('foobar');
+            }
+        };
+    }
+}

--- a/tests/AbstractMiddlewareTest.php
+++ b/tests/AbstractMiddlewareTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Diactoros\Response\TextResponse;
 
-abstract class AbstractMiddlewareTest extends TestCase
+abstract class AbstractMiddlewareTest extends \PHPUnit_Framework_TestCase
 {
     protected function getDelegate() : DelegateInterface
     {

--- a/tests/CsrfHeaderCheckMiddlewareFactoryTest.php
+++ b/tests/CsrfHeaderCheckMiddlewareFactoryTest.php
@@ -2,7 +2,6 @@
 
 namespace TheCodingMachine\Middlewares;
 
-
 use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\ServerRequest;
 

--- a/tests/CsrfHeaderCheckMiddlewareFactoryTest.php
+++ b/tests/CsrfHeaderCheckMiddlewareFactoryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TheCodingMachine\Middlewares;
+
+
+use PHPUnit\Framework\TestCase;
+use Zend\Diactoros\ServerRequest;
+
+class CsrfHeaderCheckMiddlewareFactoryTest extends AbstractMiddlewareTest
+{
+    public function testFactory()
+    {
+        $request = new ServerRequest([], [], "http://alice.com/hello", "Get");
+
+        $middleware = CsrfHeaderCheckMiddlewareFactory::createDefault();
+
+        $response = $middleware->process($request, $this->getDelegate());
+
+        $this->assertSame('foobar', (string) $response->getBody());
+    }
+}

--- a/tests/CsrfHeaderCheckMiddlewareTest.php
+++ b/tests/CsrfHeaderCheckMiddlewareTest.php
@@ -18,24 +18,12 @@ class CsrfHeaderCheckMiddlewareTest extends AbstractMiddlewareTest
     {
         $request = new ServerRequest([], [], "http://alice.com/hello", "Get");
 
-        $middleware = new CsrfHeaderCheckMiddleware(IsSafeHttpMethod::fromDefaultSafeMethods());
+        $middleware = CsrfHeaderCheckMiddlewareFactory::createDefault();
 
 
         $response = $middleware->process($request, $this->getDelegate());
 
         $this->assertSame('foobar', (string) $response->getBody());
-    }
-
-    public function testFailingPostRequestNoOrigin()
-    {
-        $request = new ServerRequest([], [], "http://alice.com/hello", "Post");
-
-        $middleware = new CsrfHeaderCheckMiddleware(IsSafeHttpMethod::fromDefaultSafeMethods());
-
-        $this->expectException(CsrfHeaderCheckMiddlewareException::class);
-        $this->expectExceptionMessage('Could not find neither the ORIGIN header nor the REFERER header in the HTTP request.');
-
-        $response = $middleware->process($request, $this->getDelegate());
     }
 
     public function testFailingPostRequestNoHost()
@@ -44,7 +32,7 @@ class CsrfHeaderCheckMiddlewareTest extends AbstractMiddlewareTest
         $request = $request->withHeader('Origin', "http://alice.com");
         $request = $request->withoutHeader('Host');
 
-        $middleware = new CsrfHeaderCheckMiddleware(IsSafeHttpMethod::fromDefaultSafeMethods());
+        $middleware = CsrfHeaderCheckMiddlewareFactory::createDefault();
 
         $this->expectException(CsrfHeaderCheckMiddlewareException::class);
         $this->expectExceptionMessage('Could not find the HOST header in the HTTP request.');
@@ -57,7 +45,7 @@ class CsrfHeaderCheckMiddlewareTest extends AbstractMiddlewareTest
         $request = new ServerRequest([], [], "http://alice.com/hello", "Post");
         $request = $request->withHeader('Origin', "http://alice.com");
 
-        $middleware = new CsrfHeaderCheckMiddleware(IsSafeHttpMethod::fromDefaultSafeMethods());
+        $middleware = CsrfHeaderCheckMiddlewareFactory::createDefault();
 
         $response = $middleware->process($request, $this->getDelegate());
 
@@ -69,20 +57,7 @@ class CsrfHeaderCheckMiddlewareTest extends AbstractMiddlewareTest
         $request = new ServerRequest([], [], "http://alice.com:8080/hello", "Post");
         $request = $request->withHeader('Origin', "http://alice.com:8080");
 
-        $middleware = new CsrfHeaderCheckMiddleware(IsSafeHttpMethod::fromDefaultSafeMethods());
-
-        $response = $middleware->process($request, $this->getDelegate());
-
-        $this->assertSame('foobar', (string) $response->getBody());
-    }
-
-    public function testSuccessfullPostWithRefererAndForwardedHostAndPort()
-    {
-        $request = new ServerRequest([], [], "http://bob.com/hello", "Post");
-        $request = $request->withHeader('Referer', "http://alice.com");
-        $request = $request->withHeader('X-Forwarded-Host', "alice.com");
-
-        $middleware = new CsrfHeaderCheckMiddleware(IsSafeHttpMethod::fromDefaultSafeMethods());
+        $middleware = CsrfHeaderCheckMiddlewareFactory::createDefault();
 
         $response = $middleware->process($request, $this->getDelegate());
 
@@ -94,7 +69,7 @@ class CsrfHeaderCheckMiddlewareTest extends AbstractMiddlewareTest
         $request = new ServerRequest([], [], "http://alice.com/hello", "Post");
         $request = $request->withHeader('Origin', "http://eve.com");
 
-        $middleware = new CsrfHeaderCheckMiddleware(IsSafeHttpMethod::fromDefaultSafeMethods());
+        $middleware = CsrfHeaderCheckMiddlewareFactory::createDefault();
 
         $this->expectException(CsrfHeaderCheckMiddlewareException::class);
         $this->expectExceptionMessage('Potential CSRF attack stopped. Source origin and target origin do not match.');
@@ -107,7 +82,7 @@ class CsrfHeaderCheckMiddlewareTest extends AbstractMiddlewareTest
         $request = $request->withHeader('Origin', "http://eve.com");
         $request = $request->withAddedHeader('Origin', "http://alice.com");
 
-        $middleware = new CsrfHeaderCheckMiddleware(IsSafeHttpMethod::fromDefaultSafeMethods());
+        $middleware = CsrfHeaderCheckMiddlewareFactory::createDefault();
 
         $this->expectException(CsrfHeaderCheckMiddlewareException::class);
         $this->expectExceptionMessage('Unexpected request: more than one ORIGIN header sent.');

--- a/tests/OriginFetchers/HostHeaderTest.php
+++ b/tests/OriginFetchers/HostHeaderTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace TheCodingMachine\Middlewares\OriginFetchers;
+
+use TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareException;
+use Zend\Diactoros\ServerRequest;
+
+class HostHeaderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFetchHost()
+    {
+        $request = new ServerRequest([], [], "http://alice.com:8080/hello", "Post");
+
+        $hostHeader = new HostHeader();
+
+        $hosts = $hostHeader($request);
+
+        $this->assertSame(['alice.com'], $hosts);
+    }
+
+    public function testForwardedHostIgnored()
+    {
+        $request = new ServerRequest([], [], "http://alice.com:8080/hello", "Post");
+        $request = $request->withHeader('X-Forwarded-Host', 'eve.com');
+
+        $hostHeader = new HostHeader();
+
+        $hosts = $hostHeader($request);
+
+        $this->assertSame(['alice.com'], $hosts);
+    }
+
+    public function testMultipleHostHeaders()
+    {
+        $request = new ServerRequest([], [], "http://alice.com:8080/hello", "Post");
+        $request = $request->withAddedHeader('Host', 'eve.com');
+
+        $hostHeader = new HostHeader();
+
+        $this->expectException(CsrfHeaderCheckMiddlewareException::class);
+        $this->expectExceptionMessage("Unexpected request: more than one HOST header sent.");
+        $hostHeader($request);
+    }
+}

--- a/tests/OriginFetchers/OriginOrRefererHeaderTest.php
+++ b/tests/OriginFetchers/OriginOrRefererHeaderTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace TheCodingMachine\Middlewares\OriginFetchers;
+
+use PHPUnit\Framework\TestCase;
+use TheCodingMachine\Middlewares\CsrfHeaderCheckMiddlewareException;
+use Zend\Diactoros\ServerRequest;
+
+class OriginOrRefererHeaderTest extends TestCase
+{
+    public function testFailingPostRequestNoOrigin()
+    {
+        $request = new ServerRequest([], [], "http://alice.com/hello", "Post");
+
+        $headerFetcher = new OriginOrRefererHeader();
+
+        $this->expectException(CsrfHeaderCheckMiddlewareException::class);
+        $this->expectExceptionMessage('Could not find neither the ORIGIN header nor the REFERER header in the HTTP request.');
+
+        $headerFetcher($request);
+    }
+
+    public function testOriginFetch()
+    {
+        $request = new ServerRequest([], [], "http://alice.com/hello", "Post");
+        $request = $request->withHeader('Origin', 'http://eve.com');
+
+        $headerFetcher = new OriginOrRefererHeader();
+
+        $this->assertSame('eve.com', $headerFetcher($request));
+    }
+
+    public function testRefererFetch()
+    {
+        $request = new ServerRequest([], [], "http://alice.com/hello", "Post");
+        $request = $request->withHeader('Referer', 'http://eve.com/foobar?id=42');
+
+        $headerFetcher = new OriginOrRefererHeader();
+
+        $this->assertSame('eve.com', $headerFetcher($request));
+    }
+}

--- a/tests/SafeRequests/CompositeIsSafeTest.php
+++ b/tests/SafeRequests/CompositeIsSafeTest.php
@@ -6,7 +6,7 @@ namespace TheCodingMachine\Middlewares\SafeRequests;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
-class CompositeIsSafeTest extends TestCase
+class CompositeIsSafeTest extends \PHPUnit_Framework_TestCase
 {
     private function getChecker(bool $result): IsSafeHttpRequestInterface
     {

--- a/tests/SafeRequests/CompositeIsSafeTest.php
+++ b/tests/SafeRequests/CompositeIsSafeTest.php
@@ -2,7 +2,6 @@
 
 namespace TheCodingMachine\Middlewares\SafeRequests;
 
-
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -10,8 +9,7 @@ class CompositeIsSafeTest extends \PHPUnit_Framework_TestCase
 {
     private function getChecker(bool $result): IsSafeHttpRequestInterface
     {
-        return new class($result) implements IsSafeHttpRequestInterface
-        {
+        return new class($result) implements IsSafeHttpRequestInterface {
             /**
              * @var bool
              */
@@ -19,7 +17,6 @@ class CompositeIsSafeTest extends \PHPUnit_Framework_TestCase
 
             public function __construct(bool $result)
             {
-
                 $this->result = $result;
             }
 
@@ -49,5 +46,4 @@ class CompositeIsSafeTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($composite($request));
     }
-
 }

--- a/tests/SafeRequests/CompositeIsSafeTest.php
+++ b/tests/SafeRequests/CompositeIsSafeTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace TheCodingMachine\Middlewares\SafeRequests;
+
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CompositeIsSafeTest extends TestCase
+{
+    private function getChecker(bool $result): IsSafeHttpRequestInterface
+    {
+        return new class($result) implements IsSafeHttpRequestInterface
+        {
+            /**
+             * @var bool
+             */
+            private $result;
+
+            public function __construct(bool $result)
+            {
+
+                $this->result = $result;
+            }
+
+            public function __invoke(ServerRequestInterface $request): bool
+            {
+                return $this->result;
+            }
+        };
+    }
+
+    public function testCompositeAllFalse()
+    {
+        /* @var $request RequestInterface|\PHPUnit_Framework_MockObject_MockObject */
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+
+        $composite = new CompositeIsSafe($this->getChecker(false), $this->getChecker(false));
+
+        $this->assertFalse($composite($request));
+    }
+
+    public function testCompositeOneTrue()
+    {
+        /* @var $request RequestInterface|\PHPUnit_Framework_MockObject_MockObject */
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+
+        $composite = new CompositeIsSafe($this->getChecker(false), $this->getChecker(true));
+
+        $this->assertTrue($composite($request));
+    }
+
+}

--- a/tests/SafeRequests/IsBypassedCheckTest.php
+++ b/tests/SafeRequests/IsBypassedCheckTest.php
@@ -6,7 +6,7 @@ namespace TheCodingMachine\Middlewares\SafeRequests;
 use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\ServerRequest;
 
-class IsBypassedCheckTest extends TestCase
+class IsBypassedCheckTest extends \PHPUnit_Framework_TestCase
 {
     public function testBypassCheck()
     {

--- a/tests/SafeRequests/IsBypassedCheckTest.php
+++ b/tests/SafeRequests/IsBypassedCheckTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TheCodingMachine\Middlewares\SafeRequests;
+
+
+use PHPUnit\Framework\TestCase;
+use Zend\Diactoros\ServerRequest;
+
+class IsBypassedCheckTest extends TestCase
+{
+    public function testBypassCheck()
+    {
+        $check = IsBypassedCheck::fromDefault();
+
+        $request = new ServerRequest([], [], '/', 'GET');
+
+        $this->assertFalse($check($request));
+
+        $request = $request->withAttribute('TheCodingMachine\\BypassCsrf', true);
+
+        $this->assertTrue($check($request));
+    }
+}

--- a/tests/SafeRequests/IsBypassedCheckTest.php
+++ b/tests/SafeRequests/IsBypassedCheckTest.php
@@ -2,7 +2,6 @@
 
 namespace TheCodingMachine\Middlewares\SafeRequests;
 
-
 use PHPUnit\Framework\TestCase;
 use Zend\Diactoros\ServerRequest;
 

--- a/tests/SafeRequests/IsSafeHttpMethodTest.php
+++ b/tests/SafeRequests/IsSafeHttpMethodTest.php
@@ -10,7 +10,7 @@ use Psr\Http\Message\ServerRequestInterface;
 /**
  * @covers \TheCodingMachine\Middlewares\SafeRequests\IsSafeHttpMethod
  */
-final class IsSafeHttpMethodTest extends TestCase
+final class IsSafeHttpMethodTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider httpMethodsProvider

--- a/tests/SafeRequests/IsSafeHttpMethodTest.php
+++ b/tests/SafeRequests/IsSafeHttpMethodTest.php
@@ -1,0 +1,149 @@
+<?php
+declare(strict_types=1);
+
+namespace TheCodingMachine\Middlewares\SafeRequests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @covers \TheCodingMachine\Middlewares\SafeRequests\IsSafeHttpMethod
+ */
+final class IsSafeHttpMethodTest extends TestCase
+{
+    /**
+     * @dataProvider httpMethodsProvider
+     *
+     * @param array  $safeMethods
+     * @param string $httpMethod
+     * @param bool   $expectedResult
+     */
+    public function testSafeMethods(array $safeMethods, string $httpMethod, bool $expectedResult)
+    {
+        /* @var $request RequestInterface|\PHPUnit_Framework_MockObject_MockObject */
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+
+        $request->expects(self::any())->method('getMethod')->willReturn($httpMethod);
+
+        self::assertSame($expectedResult, (new IsSafeHttpMethod(...$safeMethods))->__invoke($request));
+    }
+
+    public function httpMethodsProvider() : array
+    {
+        return [
+            'empty' => [
+                [],
+                'GET',
+                false,
+            ],
+            'GET only' => [
+                ['GET'],
+                'GET',
+                true,
+            ],
+            'get only' => [
+                ['get'],
+                'GET',
+                true,
+            ],
+            'GET only, matching lowercase get' => [
+                ['GET'],
+                'get',
+                true,
+            ],
+            'GET only, non-matching method' => [
+                ['GET'],
+                'PUT',
+                false,
+            ],
+            'GET, PUT only, matching method' => [
+                ['GET', 'PUT'],
+                'PUT',
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider safeDefaultsMatchingProvider
+     *
+     * @param string $httpMethod
+     * @param bool   $expectedResult
+     */
+    public function testSafeMethodsWithDefaults(string $httpMethod, bool $expectedResult)
+    {
+        /* @var $request RequestInterface|\PHPUnit_Framework_MockObject_MockObject */
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+
+        $request->expects(self::any())->method('getMethod')->willReturn($httpMethod);
+
+        self::assertSame($expectedResult, IsSafeHttpMethod::fromDefaultSafeMethods()->__invoke($request));
+    }
+
+    public function safeDefaultsMatchingProvider() : array
+    {
+        return [
+            'empty' => [
+                '',
+                false,
+            ],
+            'GET' => [
+                'GET',
+                true,
+            ],
+            'get' => [
+                'get',
+                true,
+            ],
+            'HEAD' => [
+                'HEAD',
+                true,
+            ],
+            'head' => [
+                'head',
+                true,
+            ],
+            'OPTIONS' => [
+                'OPTIONS',
+                true,
+            ],
+            'options' => [
+                'options',
+                true,
+            ],
+            'DELETE' => [
+                'DELETE',
+                false,
+            ],
+            'delete' => [
+                'delete',
+                false,
+            ],
+            'POST' => [
+                'POST',
+                false,
+            ],
+            'post' => [
+                'post',
+                false,
+            ],
+            'PUT' => [
+                'PUT',
+                false,
+            ],
+            'put' => [
+                'put',
+                false,
+            ],
+            'UNKNOWN' => [
+                'UNKNOWN',
+                false,
+            ],
+            'unknown' => [
+                'unknown',
+                false,
+            ],
+        ];
+    }
+}

--- a/tests/SafeRequests/IsSafeHttpRouteTest.php
+++ b/tests/SafeRequests/IsSafeHttpRouteTest.php
@@ -11,7 +11,7 @@ use Psr\Http\Message\UriInterface;
 /**
  * @covers \TheCodingMachine\Middlewares\SafeRequests\IsSafeHttpRoute
  */
-final class IsSafeHttpRouteTest extends TestCase
+final class IsSafeHttpRouteTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @dataProvider routesProvider

--- a/tests/SafeRequests/IsSafeHttpRouteTest.php
+++ b/tests/SafeRequests/IsSafeHttpRouteTest.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace TheCodingMachine\Middlewares\SafeRequests;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * @covers \TheCodingMachine\Middlewares\SafeRequests\IsSafeHttpRoute
+ */
+final class IsSafeHttpRouteTest extends TestCase
+{
+    /**
+     * @dataProvider routesProvider
+     *
+     * @param array  $routes
+     * @param string $path
+     * @param bool   $expectedResult
+     */
+    public function testSafeRoutes(array $routes, string $path, bool $expectedResult)
+    {
+        /* @var $uri UriInterface|\PHPUnit_Framework_MockObject_MockObject */
+        $uri = $this->getMockBuilder(UriInterface::class)->getMock();
+
+        $uri->expects(self::any())->method('getPath')->willReturn($path);
+
+        /* @var $request RequestInterface|\PHPUnit_Framework_MockObject_MockObject */
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+
+        $request->expects(self::any())->method('getUri')->willReturn($uri);
+
+        self::assertSame($expectedResult, (new IsSafeHttpRoute(...$routes))->__invoke($request));
+    }
+
+    public function routesProvider() : array
+    {
+        return [
+            'empty' => [
+                [],
+                '/',
+                false,
+            ],
+            'request one' => [
+                ['#/#'],
+                '/',
+                true,
+            ],
+            'many routes' => [
+                ['#^/foo$#', '#^/bar$#'],
+                '/bar',
+                true,
+            ],
+            'many routes' => [
+                ['#^/foo$#', '#^/bar$#'],
+                '/baz',
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Following comments by @Ocramius, this PR:

- puts the logic of checking whether the request must be validated or not behind a separate interface (`IsSafeHttpRequestInterface`)
- checks all requests that are not in a whitelist (GET / HEAD / OPTIONS) rather that applying a less secure blacklist
- makes the code easier to read using early return statements (don't know why I did not use those upfront!)

Also, this PR:

- adds ways to bypass the CSRF check 
    - by route
    - by using a special request attribute

TODO before merging:

- [ ] make sure that the "X-Forwarded-Host" header cannot be set from the browser. Otherwise, we need to add an additional parameter to the middleware to decide whether we should look at this parameter (if it was added by a reverse-proxy) or whether we should ignore it (if we are facing the open internet directly)